### PR TITLE
Modify the dtype of heatmap_weights to speed up the calculation

### DIFF
--- a/mmpose/codecs/spr.py
+++ b/mmpose/codecs/spr.py
@@ -131,7 +131,7 @@ class SPR(BaseKeypointCodec):
         Returns:
             np.ndarray: Heatmap weight array in the same shape with heatmaps
         """
-        heatmap_weights = np.ones(heatmaps.shape) * bg_weight
+        heatmap_weights = np.ones(heatmaps.shape, dtype=np.float32) * bg_weight
         heatmap_weights[heatmaps > 0] = fg_weight
         return heatmap_weights
 


### PR DESCRIPTION
## Motivation

The default data type generated by np.ones is float64, which causes the data type of heatmap_weights to be float64 as well. Finally, it affects the efficiency of calculating KeypointMSELoss.

## Modification

Modify the dtype of np.ones to speed up subsequent calculations.


## Use cases (Optional)

We have verified on related configurations, such as configs/body_2d_keypoint/dekr/coco/dekr_hrnet-w32_8xb10-140e_coco-512x512.py, there is no accuracy problem after modification, and the performance is improved by about 1.5%

Environment information: Tesla V100, torch 2.0.0

## Checklist

**Before PR**:

- [√] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [√] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmpose/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [√] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [√] New functionalities are covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [√] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [√] CLA has been signed and all committers have signed the CLA in this PR.
